### PR TITLE
Attempt to optimize images with @11ty/eleventy-img and restructure as…

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,3 +1,5 @@
+const { eleventyImageTransformPlugin } = require("@11ty/eleventy-img");
+
 module.exports = function (eleventyConfig) {
   eleventyConfig.addPassthroughCopy("assets");
   eleventyConfig.setDataDeepMerge(false);
@@ -22,6 +24,27 @@ module.exports = function (eleventyConfig) {
   });
 
   eleventyConfig.addPassthroughCopy({ 'src/robots.txt': 'robots.txt' });
+
+  eleventyConfig.addPlugin(eleventyImageTransformPlugin, {
+    // Output formats (in order of preference)
+    formats: ["avif", "webp", "jpeg"],
+
+    // Default image widths. "auto" keeps the original width.
+    // Add more widths here if needed, e.g., [300, 600, "auto"]
+    widths: ["auto"],
+
+    // Default attributes for the <img> element
+    defaultAttributes: {
+      loading: "lazy",
+      decoding: "async",
+    },
+
+    // We are using the HTML Transform mode, which is generally good at
+    // auto-detecting paths. We will omit urlPath and outputDir for now
+    // as per documentation recommendations for this mode.
+    // outputDir: "./_site/assets/images/", // Only uncomment and adjust if auto-detection fails
+    // urlPath: "/assets/images/", // Only uncomment and adjust if auto-detection fails
+  });
 
   return {
     passthroughFileCopy: true,

--- a/src/_data/homologacion.json
+++ b/src/_data/homologacion.json
@@ -3,13 +3,13 @@
   "subTitle": "Cursos Homologados",
   "entidades":[
     {
-      "img": "assets/images/homologacion/Cuerpo-Nacional-de-Policia.svg"
+      "img": "/assets/images/homologacion/Cuerpo-Nacional-de-Policia.svg"
     },
     {
-      "img": "assets/images/homologacion/MIR.Gob.Web.svg"
+      "img": "/assets/images/homologacion/MIR.Gob.Web.svg"
     },
     {
-      "img": "assets/images/homologacion/Escudo_Oficial_Guardia_Civil.svg"
+      "img": "/assets/images/homologacion/Escudo_Oficial_Guardia_Civil.svg"
     }
   ]
 }


### PR DESCRIPTION
…sets

This commit includes the initial setup of the @11ty/eleventy-img plugin and several attempts to address path resolution issues.

Key changes and steps taken:
1. Added @11ty/eleventy-img plugin to .eleventy.js with AVIF, WebP, and JPEG output formats, auto widths, and lazy/async attributes.
2. Identified that initial build failures were due to the plugin expecting absolute image paths (e.g., /assets/images/foo.jpg) to resolve to src/assets/images/foo.jpg, while your project's assets were at the root assets/ directory.
3. I attempted to modify paths (e.g., to ../assets/), but this was found to be incorrect and was reverted.
4. The primary strategy shifted to relocating the entire top-level 'assets/' directory into 'src/assets/' and updating the Eleventy passthrough copy configuration.

Stuck Point:
I was unable to complete the relocation of the 'assets/' directory into 'src/assets/' (including moving all subdirectories like images, css, js, vendor, and updating .eleventy.js) successfully despite multiple attempts and a long waiting period. I ultimately stopped working on this.

The next intended steps were to break down this asset relocation into more granular actions. This commit captures the state before executing those granular steps.